### PR TITLE
feat: 添加隐私选项

### DIFF
--- a/src/api/domain.ts
+++ b/src/api/domain.ts
@@ -28,6 +28,7 @@ export interface DomainCreateRequest {
   api_secret: string;
   name: string;
   vendor: DomainVendor;
+  privacy: boolean;
 }
 
 export type DomainUpdateRequest = Partial<DomainCreateRequest>;
@@ -42,6 +43,7 @@ export interface DomainItem {
   Name: string;
   Users: null;
   vendor: DomainVendor;
+  privacy: boolean;
 }
 
 export const utils = {
@@ -50,6 +52,7 @@ export const utils = {
       name: item.Name,
       vendor: item.vendor,
       ICP_reg: item.ICP_reg,
+      privacy: item.privacy,
     };
   },
 };
@@ -95,7 +98,9 @@ export function update(id: number, data: DomainUpdateRequest, token = getToken()
       Authorization: `Bearer ${token}`,
     },
     data: Object.fromEntries(
-      Object.entries(data).filter(([k, v]) => k !== 'ICP_reg' && !!v),
+      Object.entries(data).filter(
+        ([k, v]) => k !== 'ICP_reg' && (!!v || k === 'privacy'),
+      ),
     ),
   });
 }

--- a/src/pages/Domain/index.tsx
+++ b/src/pages/Domain/index.tsx
@@ -262,7 +262,6 @@ const Home: React.FC = () => {
           <Form.Item
             label="公开"
             name="privacy"
-            initialValue={!!form.getFieldValue('privacy')}
             getValueProps={(value) => ({
               value: !Boolean(value),
             })}

--- a/src/pages/Domain/index.tsx
+++ b/src/pages/Domain/index.tsx
@@ -260,6 +260,19 @@ const Home: React.FC = () => {
             />
           </Form.Item>
           <Form.Item
+            label="公开"
+            name="privacy"
+            initialValue={!!form.getFieldValue('privacy')}
+            getValueProps={(value) => ({
+              value: !Boolean(value),
+            })}
+            normalize={(v) => {
+              return !v;
+            }}
+            help="设置非公开后，只有域名创建人能查看此域名信息">
+            <Switch checkedChildren="是" unCheckedChildren="否" />
+          </Form.Item>
+          <Form.Item
             name="vendor"
             label="DNS 接入方"
             rules={[{ required: true, message: '请选择DNS接入方' }]}>

--- a/src/pages/Domain/index.tsx
+++ b/src/pages/Domain/index.tsx
@@ -262,13 +262,14 @@ const Home: React.FC = () => {
           <Form.Item
             label="公开"
             name="privacy"
+            initialValue={false}
             getValueProps={(value) => ({
               value: !Boolean(value),
             })}
             normalize={(v) => {
               return !v;
             }}
-            help="设置非公开后，只有域名创建人能查看此域名信息">
+            help="非公开：只有域名创建人能查看此域名信息">
             <Switch checkedChildren="是" unCheckedChildren="否" />
           </Form.Item>
           <Form.Item


### PR DESCRIPTION
后端新增Privacy字段，详情请见：https://github.com/BYRIO/Domain0/pull/8

前端为保持可读性，将privacy转换为public，即是否公开